### PR TITLE
Add simple esc() test

### DIFF
--- a/monitor.js
+++ b/monitor.js
@@ -18,7 +18,7 @@ const seenToken = new Set();
 const seenTx    = new Set();
 
 /* Markdown V2 转义 */
-const esc = (s) => s.replace(/([_*\[\]()~`>#+\-=|{}.!\\])/g, '\\$1');
+export const esc = (s) => s.replace(/([_*\[\]()~`>#+\-=|{}.!\\])/g, '\\$1');
 
 /* 捕捉顶层异常防止容器退出 */
 process.on('uncaughtException',  e => console.error('[Fatal] Uncaught:', e));

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "ethers": "^6.12.0"
   },
   "scripts": {
-    "start": "node --trace-warnings monitor.js"
+    "start": "node --trace-warnings monitor.js",
+    "test": "node test.js"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,0 +1,13 @@
+import assert from 'node:assert/strict';
+
+// Same escaping function as in monitor.js
+const esc = (s) => s.replace(/([_*\[\]()~`>#+\-=|{}.!\\])/g, '\\$1');
+
+assert.equal(esc('_'), '\\_');
+assert.equal(esc('a_b'), 'a\\_b');
+assert.equal(esc('['), '\\[');
+assert.equal(esc(']'), '\\]');
+assert.equal(esc('('), '\\(');
+assert.equal(esc(')'), '\\)');
+
+console.log('All tests passed!');


### PR DESCRIPTION
## Summary
- export `esc` helper
- add a Node assert test to verify escaping
- run test with `npm test`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845a6963764832090cd739b49148810