### PR TITLE
Fix polling overlap

### DIFF
--- a/monitor.js
+++ b/monitor.js
@@ -36,7 +36,7 @@ async function getPriceUsd(addr){
 }
 
 /* ---------- 主循环 ---------- */
-setInterval(async () => {
+async function poll(){
   try {
     const latest = BigInt(await provider.getBlockNumber());
     if (lastBlock === 0n) lastBlock = latest - 1n;
@@ -102,7 +102,11 @@ setInterval(async () => {
     lastBlock = latest;
   } catch (e) {
     console.error('[Watcher] 轮询出错：', e.message);
+  } finally {
+    setTimeout(poll, POLL_MS);
   }
-}, POLL_MS);
+}
+
+poll();
 
 console.log('[Watcher] 轮询版已启动，每 10 秒检查一次…');


### PR DESCRIPTION
## Summary
- prevent concurrent polling by using recursive `setTimeout`

## Testing
- `node --check monitor.js`
- `node monitor.js` *(fails: Cannot find package 'ethers')*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6845a4e3a9448320a71731a29976ebb8