### PR TITLE
Expand monitoring coverage

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -1,0 +1,13 @@
+import { ethers } from 'ethers';
+
+export const esc = (s) => s.replace(/([_*\[\]()~`>#+\-=|{}.!\\])/g, '\\$1');
+
+export function formatTx(tx) {
+  return [
+    '🚨 *交易提醒*',
+    `📤 **From**：\`${tx.from.toLowerCase()}\``,
+    `📥 **To**：\`${tx.to ? tx.to.toLowerCase() : '(null)'}\``,
+    `💸 **Value**：${esc(ethers.formatUnits(tx.value, 18))}`,
+    `🔍 **Tx**：\`${tx.hash}\``
+  ].join('\n');
+}

--- a/monitor.js
+++ b/monitor.js
@@ -1,4 +1,5 @@
 import { ethers } from 'ethers';
+import { esc, formatTx } from './helpers.js';
 
 /* ---------- 参数检测 ---------- */
 // 使用 --once 参数时仅轮询一次
@@ -18,11 +19,7 @@ const provider = new ethers.JsonRpcProvider(RPC_HTTP);
 /* ---------- 轮询 & 去重 ---------- */
 const POLL_MS   = 10_000;
 let   lastBlock = 0n;
-const seenToken = new Set();
 const seenLog   = new Set();
-
-/* Markdown V2 转义 */
-export const esc = (s) => s.replace(/([_*\[\]()~`>#+\-=|{}.!\\])/g, '\\$1');
 
 /* 捕捉顶层异常防止容器退出 */
 process.on('uncaughtException',  e => console.error('[Fatal] Uncaught:', e));
@@ -45,6 +42,25 @@ async function poll(){
     const latest = BigInt(await provider.getBlockNumber());
     if (lastBlock === 0n) lastBlock = latest - 1n;
 
+    for (let bn = lastBlock + 1n; bn <= latest; bn++) {
+      const block = await provider.getBlockWithTransactions(bn);
+      for (const tx of block.transactions) {
+        if (tx.from.toLowerCase() === TARGET || (tx.to && tx.to.toLowerCase() === TARGET)) {
+          const msg = formatTx(tx);
+          await fetch(`https://api.telegram.org/bot${BOT_TOKEN}/sendMessage`, {
+            method : 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body   : JSON.stringify({
+              chat_id   : CHAT_ID,
+              text      : msg,
+              parse_mode: 'MarkdownV2'
+            })
+          });
+          console.log('[Watcher] 已推送交易', tx.hash);
+        }
+      }
+    }
+
     const transferTopic = ethers.id('Transfer(address,address,uint256)');
     const paddedTarget  = ethers.zeroPadValue(TARGET, 32);
 
@@ -64,6 +80,13 @@ async function poll(){
       logs.push(...part);
     }
 
+    const addrPart = await provider.getLogs({
+      fromBlock: ethers.toQuantity(lastBlock + 1n),
+      toBlock  : ethers.toQuantity(latest),
+      address  : TARGET
+    });
+    logs.push(...addrPart);
+
     for (const lg of logs) {
       const logId = `${lg.transactionHash}:${lg.logIndex}`;
       if (seenLog.has(logId)) continue;
@@ -71,7 +94,6 @@ async function poll(){
 
       if (lg.topics[0] === transferTopic) {
         const token = lg.address.toLowerCase();
-        if (seenToken.has(token)) continue;
 
         /* 读取 symbol & decimals */
         let symbol='?', decimals=18;
@@ -85,7 +107,6 @@ async function poll(){
 
         /* 收到数量 */
         const amount = ethers.formatUnits(BigInt(lg.data), decimals);
-        if (Number(amount) <= 100000) continue;
 
         /* 单价 & 总价值 */
         const price  = await getPriceUsd(token);
@@ -113,7 +134,6 @@ async function poll(){
         });
 
         console.log('[Watcher] 已推送', symbol);
-        seenToken.add(token);
       } else {
         const msg = [
           '🚨 *事件提醒*',

--- a/test.js
+++ b/test.js
@@ -1,13 +1,26 @@
 import assert from 'node:assert/strict';
+import { esc, formatTx } from './helpers.js';
 
-// Same escaping function as in monitor.js
-const esc = (s) => s.replace(/([_*\[\]()~`>#+\-=|{}.!\\])/g, '\\$1');
-
+// tests for esc
 assert.equal(esc('_'), '\\_');
 assert.equal(esc('a_b'), 'a\\_b');
 assert.equal(esc('['), '\\[');
 assert.equal(esc(']'), '\\]');
 assert.equal(esc('('), '\\(');
 assert.equal(esc(')'), '\\)');
+
+// test formatTx helper
+const tx = {
+  from: '0x1111111111111111111111111111111111111111',
+  to: '0x2222222222222222222222222222222222222222',
+  value: 1n * 10n ** 18n,
+  hash: '0xabc'
+};
+
+const msg = formatTx(tx);
+assert(msg.includes(tx.from));
+assert(msg.includes(tx.to));
+assert(msg.includes('1'));
+assert(msg.includes(tx.hash));
 
 console.log('All tests passed!');


### PR DESCRIPTION
## Summary
- remove token-level deduplication and filters
- monitor every block for transactions involving the watched address
- query logs emitted by the target address
- factor out helpers and add a message formatter
- add tests for the formatter

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846ede7b37083208c106696adc5e2d9