### PR TITLE
Expand monitoring coverage

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -1,0 +1,13 @@
+import { ethers } from 'ethers';
+
+export const esc = (s) => s.replace(/([_*\[\]()~`>#+\-=|{}.!\\])/g, '\\$1');
+
+export function formatTx(tx) {
+  return [
+    '🚨 *交易提醒*',
+    `📤 **From**：\`${tx.from.toLowerCase()}\``,
+    `📥 **To**：\`${tx.to ? tx.to.toLowerCase() : '(null)'}\``,
+    `💸 **Value**：${esc(ethers.formatUnits(tx.value, 18))}`,
+    `🔍 **Tx**：\`${tx.hash}\``
+  ].join('\n');
+}

--- a/test.js
+++ b/test.js
@@ -1,13 +1,26 @@
 import assert from 'node:assert/strict';
+import { esc, formatTx } from './helpers.js';
 
-// Same escaping function as in monitor.js
-const esc = (s) => s.replace(/([_*\[\]()~`>#+\-=|{}.!\\])/g, '\\$1');
-
+// tests for esc
 assert.equal(esc('_'), '\\_');
 assert.equal(esc('a_b'), 'a\\_b');
 assert.equal(esc('['), '\\[');
 assert.equal(esc(']'), '\\]');
 assert.equal(esc('('), '\\(');
 assert.equal(esc(')'), '\\)');
+
+// test formatTx helper
+const tx = {
+  from: '0x1111111111111111111111111111111111111111',
+  to: '0x2222222222222222222222222222222222222222',
+  value: 1n * 10n ** 18n,
+  hash: '0xabc'
+};
+
+const msg = formatTx(tx);
+assert(msg.includes(tx.from));
+assert(msg.includes(tx.to));
+assert(msg.includes('1'));
+assert(msg.includes(tx.hash));
 
 console.log('All tests passed!');


### PR DESCRIPTION
## Summary
- remove token-level deduplication and filters
- monitor every block for transactions involving the watched address
- query logs emitted by the target address
- factor out helpers and add a message formatter
- add tests for the formatter
- add fallback when `getBlockWithTransactions` is missing

## Testing
- `npm test`
- `npm start -- --once`

------
https://chatgpt.com/codex/tasks/task_e_6846ede7b37083208c106696adc5e2d9