### PR TITLE
Add event parsing and cleaner alerts

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -4,10 +4,60 @@ export const esc = (s) => s.replace(/([_*\[\]()~`>#+\-=|{}.!\\])/g, '\\$1');
 
 export function formatTx(tx) {
   return [
-    '🚨 *交易提醒*',
+    `🚨 *交易提醒*`,
     `📤 **From**：\`${tx.from ? tx.from.toLowerCase() : '(null)'}\``,
     `📥 **To**：\`${tx.to ? tx.to.toLowerCase() : '(null)'}\``,
     `💸 **Value**：${esc(ethers.formatUnits(tx.value, 18))}`,
     `🔍 **Tx**：\`${tx.hash}\``
   ].join('\n');
+}
+
+async function lookupSignature(topic0) {
+  try {
+    const url = `https://www.4byte.directory/api/v1/event-signatures/?hex_signature=${topic0}`;
+    const res = await fetch(url).then(r => r.json());
+    return res.results?.[0]?.text_signature || null;
+  } catch {
+    return null;
+  }
+}
+
+export async function formatEventLog(log) {
+  const sig = await lookupSignature(log.topics[0]);
+  if (!sig) {
+    return [
+      `🚨 *事件提醒*`,
+      `🔗 **合约**：${esc(`\`${log.address.toLowerCase()}\``)}`,
+      `📝 **Topic0**：${esc(`\`${log.topics[0]}\``)}`,
+      `🔍 **Tx**：${esc(`\`${log.transactionHash}\``)}`
+    ].join('\n');
+  }
+
+  try {
+    const iface = new ethers.Interface([`event ${sig}`]);
+    const parsed = iface.parseLog(log);
+    const args = Object.entries(parsed.args)
+      .filter(([k]) => isNaN(Number(k)))
+      .map(([k, v]) => {
+        let val = v;
+        if (typeof val === 'bigint') val = val.toString();
+        if (ethers.isAddress(val)) val = val.toLowerCase();
+        return `➡️ **${k}**：${esc(String(val))}`;
+      });
+
+    return [
+      `🚨 *事件提醒*`,
+      `🔗 **合约**：${esc(`\`${log.address.toLowerCase()}\``)}`,
+      `📝 **事件**：${esc(sig)}`,
+      ...args,
+      `🔍 **Tx**：${esc(`\`${log.transactionHash}\``)}`
+    ].join('\n');
+  } catch {
+    return [
+      `🚨 *事件提醒*`,
+      `🔗 **合约**：${esc(`\`${log.address.toLowerCase()}\``)}`,
+      `📝 **事件**：${esc(sig)}`,
+      `🔍 **Tx**：${esc(`\`${log.transactionHash}\``)}`
+    ].join('\n');
+  }
 }

--- a/monitor.js
+++ b/monitor.js
@@ -1,5 +1,5 @@
 import { ethers } from 'ethers';
-import { esc, formatTx } from './helpers.js';
+import { esc, formatTx, formatEventLog } from './helpers.js';
 
 /* ---------- 参数检测 ---------- */
 // 使用 --once 参数时仅轮询一次
@@ -107,6 +107,9 @@ async function poll(){
       if (lg.topics[0] === transferTopic) {
         const token = lg.address.toLowerCase();
 
+        const fromAddr = '0x' + lg.topics[1].slice(26).toLowerCase();
+        const toAddr   = '0x' + lg.topics[2].slice(26).toLowerCase();
+
         /* 读取 symbol & decimals */
         let symbol='?', decimals=18;
         try{
@@ -126,13 +129,15 @@ async function poll(){
 
         /* 组装 Telegram 消息 */
         const msg = [
-          '🚨 *新币提醒*',
+          `🚨 *转账提醒*`,
           `🔖 **符号**：${esc(symbol)}`,
-          '🔗 **代币合约**：' + esc('`' + token + '`'),
-          `📦 **收到数量**：${esc(amount)}`,
+          `🔗 **代币合约**：${esc(`\`${token}\``)}`,
+          `📤 **From**：${esc(`\`${fromAddr}\``)}`,
+          `📥 **To**：${esc(`\`${toAddr}\``)}`,
+          `📦 **数量**：${esc(amount)}`,
           `💰 **单价**：$${price}`,
           `💵 **价值**：$${value}`,
-          '🔍 **Tx**：' + esc('`' + lg.transactionHash + '`')
+          `🔍 **Tx**：${esc(`\`${lg.transactionHash}\``)}`
         ].join('\n');
 
         await fetch(`https://api.telegram.org/bot${BOT_TOKEN}/sendMessage`, {
@@ -147,12 +152,7 @@ async function poll(){
 
         console.log('[Watcher] 已推送', symbol);
       } else {
-        const msg = [
-          '🚨 *事件提醒*',
-          '🔗 **合约**：' + esc('`' + lg.address.toLowerCase() + '`'),
-          '📝 **Topic0**：' + esc('`' + lg.topics[0] + '`'),
-          '🔍 **Tx**：' + esc('`' + lg.transactionHash + '`')
-        ].join('\n');
+        const msg = await formatEventLog(lg);
 
         await fetch(`https://api.telegram.org/bot${BOT_TOKEN}/sendMessage`, {
           method : 'POST',


### PR DESCRIPTION
## Summary
- decode arbitrary events with 4byte directory lookups
- show event parameters in Telegram alerts
- switch alert templates to template strings and remove stray quotes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846ffca8ba083208f48310bb5449214