### PR TITLE
Make Oklink links clickable and clean addresses

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -1,14 +1,16 @@
 import { ethers } from 'ethers';
 
+export const OKLINK_TX = 'https://www.oklink.com/zh-hans/bsc/tx/';
+
 export const esc = (s) => s.replace(/([_*\[\]()~`>#+\-=|{}.!\\])/g, '\\$1');
 
 export function formatTx(tx) {
   return [
     `🚨 *交易提醒*`,
-    `📤 **From**：\`${tx.from ? tx.from.toLowerCase() : '(null)'}\``,
-    `📥 **To**：\`${tx.to ? tx.to.toLowerCase() : '(null)'}\``,
+    `📤 **From**：${esc(tx.from ? tx.from.toLowerCase() : '(null)')}`,
+    `📥 **To**：${esc(tx.to ? tx.to.toLowerCase() : '(null)')}`,
     `💸 **Value**：${esc(ethers.formatUnits(tx.value, 18))}`,
-    `🔍 **Tx**：\`${tx.hash}\``
+    `🔍 **Tx**：[${esc(tx.hash)}](${OKLINK_TX}${tx.hash})`
   ].join('\n');
 }
 
@@ -27,9 +29,9 @@ export async function formatEventLog(log) {
   if (!sig) {
     return [
       `🚨 *事件提醒*`,
-      `🔗 **合约**：${esc(`\`${log.address.toLowerCase()}\``)}`,
-      `📝 **Topic0**：${esc(`\`${log.topics[0]}\``)}`,
-      `🔍 **Tx**：${esc(`\`${log.transactionHash}\``)}`
+      `🔗 **合约**：${esc(log.address.toLowerCase())}`,
+      `📝 **Topic0**：${esc(log.topics[0])}`,
+      `🔍 **Tx**：[${esc(log.transactionHash)}](${OKLINK_TX}${log.transactionHash})`
     ].join('\n');
   }
 
@@ -47,17 +49,17 @@ export async function formatEventLog(log) {
 
     return [
       `🚨 *事件提醒*`,
-      `🔗 **合约**：${esc(`\`${log.address.toLowerCase()}\``)}`,
+      `🔗 **合约**：${esc(log.address.toLowerCase())}`,
       `📝 **事件**：${esc(sig)}`,
       ...args,
-      `🔍 **Tx**：${esc(`\`${log.transactionHash}\``)}`
+      `🔍 **Tx**：[${esc(log.transactionHash)}](${OKLINK_TX}${log.transactionHash})`
     ].join('\n');
   } catch {
     return [
       `🚨 *事件提醒*`,
-      `🔗 **合约**：${esc(`\`${log.address.toLowerCase()}\``)}`,
+      `🔗 **合约**：${esc(log.address.toLowerCase())}`,
       `📝 **事件**：${esc(sig)}`,
-      `🔍 **Tx**：${esc(`\`${log.transactionHash}\``)}`
+      `🔍 **Tx**：[${esc(log.transactionHash)}](${OKLINK_TX}${log.transactionHash})`
     ].join('\n');
   }
 }

--- a/monitor.js
+++ b/monitor.js
@@ -1,5 +1,5 @@
 import { ethers } from 'ethers';
-import { esc, formatTx, formatEventLog } from './helpers.js';
+import { esc, formatTx, formatEventLog, OKLINK_TX } from './helpers.js';
 
 /* ---------- 参数检测 ---------- */
 // 使用 --once 参数时仅轮询一次
@@ -131,13 +131,13 @@ async function poll(){
         const msg = [
           `🚨 *转账提醒*`,
           `🔖 **符号**：${esc(symbol)}`,
-          `🔗 **代币合约**：${esc(`\`${token}\``)}`,
-          `📤 **From**：${esc(`\`${fromAddr}\``)}`,
-          `📥 **To**：${esc(`\`${toAddr}\``)}`,
+          `🔗 **代币合约**：${esc(token)}`,
+          `📤 **From**：${esc(fromAddr)}`,
+          `📥 **To**：${esc(toAddr)}`,
           `📦 **数量**：${esc(amount)}`,
           `💰 **单价**：$${price}`,
           `💵 **价值**：$${value}`,
-          `🔍 **Tx**：${esc(`\`${lg.transactionHash}\``)}`
+          `🔍 **Tx**：[${esc(lg.transactionHash)}](${OKLINK_TX}${lg.transactionHash})`
         ].join('\n');
 
         await fetch(`https://api.telegram.org/bot${BOT_TOKEN}/sendMessage`, {


### PR DESCRIPTION
## Summary
- export `OKLINK_TX` and clean up address formatting
- drop backticks around addresses and hashes
- show Oklink link in transfer alerts
- remove stray backticks in all alerts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6847037535b883208d90fafab151f998